### PR TITLE
Show the stack trace of a rethrown error

### DIFF
--- a/lib/Plack/Middleware/StackTrace/RethrowFriendly.pm
+++ b/lib/Plack/Middleware/StackTrace/RethrowFriendly.pm
@@ -210,6 +210,10 @@ that if you catch (C<eval> or C<try>-C<catch> for example) an error
 and rethrow (C<die> or C<croak> for example) it, the original stack
 trace not the rethrown one is displayed.
 
+When the response is displayed as an HTML, all the errors including
+rethrown ones are visible through the throwing point selector at the
+top of the HTML.
+
 =head1 SEE ALSO
 
 L<Plack::Middleware::StackTrace>


### PR DESCRIPTION
It is possible to put multiple stack trace HTML into `<iframe>` by specifying data URIs as `src` of `<iframe>` or `href` of `<a>`.
